### PR TITLE
just a simple way to pass args for uvicorn by run_server() method

### DIFF
--- a/src/fastserve/client/__init__.py
+++ b/src/fastserve/client/__init__.py
@@ -1,1 +1,0 @@
-from .vllm import vLLMClient

--- a/src/fastserve/core.py
+++ b/src/fastserve/core.py
@@ -77,10 +77,12 @@ class BaseServe:
 
     def run_server(
         self,
+        *args,
+        **kwargs
     ):
         import uvicorn
 
-        uvicorn.run(self.app)
+        uvicorn.run(self.app, *args, **kwargs)
 
     @property
     def test_client(self):

--- a/src/fastserve/core.py
+++ b/src/fastserve/core.py
@@ -75,11 +75,7 @@ class BaseServe:
     def app(self):
         return self._app
 
-    def run_server(
-        self,
-        *args,
-        **kwargs
-    ):
+    def run_server(self, *args, **kwargs):
         import uvicorn
 
         uvicorn.run(self.app, *args, **kwargs)


### PR DESCRIPTION
#### Changes
Just a simple and small change. 
*Args and **kwargs were added to the `run_server` method to allow passing parameters to Uvicorn, such as host and port. This enables the server to be containerized in the future.



#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
